### PR TITLE
dl/fix-preference-import: Fix preference import

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.22" />
+    <option name="version" value="1.9.0" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="1.9.22" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui-ktx:2.7.7'
 
     implementation libs.firebase.auth
-    implementation libs.androidx.preference
+    implementation("androidx.preference:preference-ktx:1.2.0")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)


### PR DESCRIPTION
dl/fix-preference-import: Fix preference import

The old import is deprecated 

we should be using this library according to the docs

https://developer.android.com/develop/ui/views/components/settings#:~:text=preference%20library%20is%20deprecated.,that%20the%20user%20can%20configure.